### PR TITLE
Fixes for mouseReleased()

### DIFF
--- a/src/ofxApp.cpp
+++ b/src/ofxApp.cpp
@@ -421,21 +421,6 @@ void ofxApp::RunnerApp::mousePressed(int x, int y, int button) {
 }
 
 //--------------------------------------------------------------
-void ofxApp::RunnerApp::mouseReleased() {
-	if(app->_sceneManager)
-		app->_sceneManager->mouseReleased();
-	app->mouseReleased();
-
-#ifdef OFX_APP_UTILS_USE_CONTROL_PANEL
-	if(app->bDebug) {
-		if(!app->_bEditingWarpPoints) {
-			app->controlPanel.mouseReleased();
-		}
-	}
-#endif
-}
-
-//--------------------------------------------------------------
 void ofxApp::RunnerApp::mouseReleased(int x, int y, int button) {
 	if(app->_sceneManager)
 		app->_sceneManager->mouseReleased(x, y, button);

--- a/src/ofxApp.h
+++ b/src/ofxApp.h
@@ -237,7 +237,6 @@ class ofxApp :
 				void mouseMoved(int x, int y);
 				void mouseDragged(int x, int y, int button);
 				void mousePressed(int x, int y, int button);
-				void mouseReleased();
 				void mouseReleased(int x, int y, int button);
 				
 				void windowResized(int w, int h);

--- a/src/ofxSceneManager.cpp
+++ b/src/ofxSceneManager.cpp
@@ -293,12 +293,6 @@ void ofxSceneManager::mousePressed(int x, int y, int button) {
 	}
 }
 
-void ofxSceneManager::mouseReleased() {
-	if(!_scenes.empty() && _currentScene >= 0) {
-		_currentScenePtr->mouseReleased();
-	}
-}
-
 void ofxSceneManager::mouseReleased(int x, int y, int button) {
 	if(!_scenes.empty() && _currentScene >= 0) {
 		_currentScenePtr->mouseReleased(x, y, button);

--- a/src/ofxSceneManager.h
+++ b/src/ofxSceneManager.h
@@ -105,7 +105,6 @@ class ofxSceneManager {
 		void mouseMoved(int x, int y);
 		void mouseDragged(int x, int y, int button);
 		void mousePressed(int x, int y, int button);
-		void mouseReleased();
 		void mouseReleased(int x, int y, int button);
 		
 		void dragEvent(ofDragInfo dragInfo);


### PR DESCRIPTION
mouseReleased() without parameters has been removed from openFrameworks, so it should be removed from ofxAppUtils as well.
